### PR TITLE
feat(auth-service): add secure admin invite-based registration flow a…

### DIFF
--- a/packages/auth-service/prisma/migrations/20250910074111_init/migration.sql
+++ b/packages/auth-service/prisma/migrations/20250910074111_init/migration.sql
@@ -1,0 +1,34 @@
+-- CreateTable
+CREATE TABLE "AdminInvite" (
+    "id" UUID NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "created_by" UUID NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "used" BOOLEAN NOT NULL DEFAULT false,
+    "used_at" TIMESTAMP(3),
+    "used_by" UUID,
+    "note" TEXT,
+
+    CONSTRAINT "AdminInvite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "AdminApiKey" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "key_hash" TEXT NOT NULL,
+    "name" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(3),
+    "revoked" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "AdminApiKey_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "AdminInvite_email_idx" ON "AdminInvite"("email");
+
+-- CreateIndex
+CREATE INDEX "AdminApiKey_user_id_idx" ON "AdminApiKey"("user_id");

--- a/packages/auth-service/prisma/schema.prisma
+++ b/packages/auth-service/prisma/schema.prisma
@@ -124,3 +124,29 @@ model Notification {
 
   @@index([user_id])
 }
+
+model AdminInvite {
+  id          String   @id @default(uuid()) @db.Uuid
+  token_hash  String
+  email       String
+  created_by  String   @db.Uuid
+  created_at  DateTime @default(now())
+  expires_at  DateTime
+  used        Boolean  @default(false)
+  used_at     DateTime?
+  used_by     String?  @db.Uuid
+  note        String?
+  @@index([email])
+}
+
+model AdminApiKey {
+  id          String   @id @default(uuid()) @db.Uuid
+  user_id     String   @db.Uuid
+  key_hash    String
+  name        String?
+  created_at  DateTime @default(now())
+  expires_at  DateTime?
+  revoked     Boolean  @default(false)
+
+  @@index([user_id])
+}

--- a/packages/auth-service/src/controllers/adminApiKey.controller.ts
+++ b/packages/auth-service/src/controllers/adminApiKey.controller.ts
@@ -1,0 +1,53 @@
+// packages/auth-service/src/controllers/adminApiKey.controller.ts
+import { Request, Response } from "express";
+import crypto from "crypto";
+import { prisma } from "../db/prismaClient";
+import cryptoLib from "crypto";
+
+function hashKey(raw: string) {
+  return cryptoLib.createHash("sha256").update(raw).digest("hex");
+}
+
+export async function createAdminApiKey(req: Request, res: Response) {
+  try {
+    const userId = (req as any).user.id as string;
+    const { name, daysValid } = req.body as { name?: string; daysValid?: number };
+
+    const raw = crypto.randomBytes(24).toString("hex"); // 48 chars
+    const key_hash = hashKey(raw);
+    const expires_at = daysValid ? new Date(Date.now() + daysValid * 24 * 60 * 60 * 1000) : undefined;
+
+    const rec = await prisma.adminApiKey.create({
+      data: { user_id: userId, key_hash, name: name || null, expires_at }
+    });
+
+    return res.status(201).json({ id: rec.id, key: raw }); // show raw only once
+  } catch (e) {
+    console.error("createAdminApiKey:", e);
+    return res.status(500).json({ error: { code: "INTERNAL_ERROR" } });
+  }
+}
+
+export async function listAdminApiKeys(req: Request, res: Response) {
+  try {
+    const userId = (req as any).user.id as string;
+    const items = await prisma.adminApiKey.findMany({ where: { user_id: userId }, orderBy: { created_at: "desc" } });
+    return res.json({ items });
+  } catch (e) {
+    console.error("listAdminApiKeys:", e);
+    return res.status(500).json({ error: { code: "INTERNAL_ERROR" } });
+  }
+}
+
+export async function revokeAdminApiKey(req: Request, res: Response) {
+  try {
+    const userId = (req as any).user.id as string;
+    const { id } = req.params;
+    const r = await prisma.adminApiKey.updateMany({ where: { id, user_id: userId }, data: { revoked: true } });
+    if (r.count === 0) return res.status(404).json({ error: { code: "NOT_FOUND" } });
+    return res.json({ ok: true });
+  } catch (e) {
+    console.error("revokeAdminApiKey:", e);
+    return res.status(500).json({ error: { code: "INTERNAL_ERROR" } });
+  }
+}

--- a/packages/auth-service/src/controllers/adminInvite.controller.ts
+++ b/packages/auth-service/src/controllers/adminInvite.controller.ts
@@ -1,0 +1,56 @@
+// packages/auth-service/src/controllers/adminInvite.controller.ts
+import { Request, Response } from "express";
+import bcrypt from "bcryptjs";
+import { prisma } from "../db/prismaClient";
+import { createAdminInviteRecord, hashInviteToken } from "../services/adminInvite.service";
+
+export async function createAdminInvite(req: Request, res: Response) {
+  try {
+    const createdBy = (req as any).user.id as string;
+    const { email, daysValid = 7, note } = req.body;
+    if (!email) return res.status(400).json({ error: { code: "MISSING_EMAIL" } });
+
+    const { invite, raw_token } = await createAdminInviteRecord(email, createdBy, daysValid, note);
+    // raw_token shown only once to operator
+    return res.status(201).json({ inviteId: invite.id, token: raw_token, expires_at: invite.expires_at });
+  } catch (e) {
+    console.error("createAdminInvite:", e);
+    return res.status(500).json({ error: { code: "INTERNAL_ERROR" } });
+  }
+}
+
+export async function registerWithInvite(req: Request, res: Response) {
+  try {
+    const { token, email, password, name } = req.body as { token: string; email: string; password: string; name?: string; };
+    if (!token || !email || !password) return res.status(400).json({ error: { code: "INVALID_PAYLOAD" } });
+
+    const token_hash = hashInviteToken(token);
+    const invite = await prisma.adminInvite.findFirst({ where: { token_hash } });
+    if (!invite) return res.status(400).json({ error: { code: "INVALID_INVITE" } });
+    if (invite.used) return res.status(400).json({ error: { code: "INVITE_USED" } });
+    if (invite.expires_at < new Date()) return res.status(400).json({ error: { code: "INVITE_EXPIRED" } });
+
+    // optional: enforce invite.email matches provided email
+    if (invite.email.toLowerCase() !== email.toLowerCase()) {
+      return res.status(400).json({ error: { code: "EMAIL_MISMATCH", message: "Invite email does not match" } });
+    }
+
+    // create admin user
+    const pwHash = await bcrypt.hash(password, 12);
+    const user = await prisma.user.create({
+      data: { email, password_hash: pwHash, name: name ?? "", role: "admin", status: "verified" },
+      select: { id: true, email: true, name: true, role: true, status: true }
+    });
+
+    // mark invite used
+    await prisma.adminInvite.update({
+      where: { id: invite.id },
+      data: { used: true, used_at: new Date(), used_by: user.id }
+    });
+
+    return res.status(201).json({ user });
+  } catch (e) {
+    console.error("registerWithInvite:", e);
+    return res.status(500).json({ error: { code: "INTERNAL_ERROR" } });
+  }
+}

--- a/packages/auth-service/src/middlewares/allowAdminOrApiKey.middleware.ts
+++ b/packages/auth-service/src/middlewares/allowAdminOrApiKey.middleware.ts
@@ -1,0 +1,23 @@
+// packages/auth-service/src/middlewares/allowAdminOrApiKey.middleware.ts
+import { NextFunction, Request, Response } from "express";
+import { requireApiKey } from "./apiKeyAuth.middleware.js";
+import { requireAuth } from "./authz.js"; // your existing middleware
+
+export function allowAdminOrApiKey(handler: any) {
+  // returns an express middleware that tries ApiKey first, then JWT admin
+  return async (req: Request, res: Response, next: NextFunction) => {
+    // Try ApiKey
+    try {
+      const auth = req.header("authorization") || "";
+      if (auth.startsWith("ApiKey ")) {
+        // run requireApiKey
+        return requireApiKey(req, res, next);
+      }
+      // otherwise fall back to JWT auth
+      return requireAuth(req, res, next);
+    } catch (e) {
+      console.error("allowAdminOrApiKey:", e);
+      return res.status(401).json({ error: { code: "UNAUTHENTICATED" } });
+    }
+  };
+}

--- a/packages/auth-service/src/middlewares/apiKeyAuth.middleware.ts
+++ b/packages/auth-service/src/middlewares/apiKeyAuth.middleware.ts
@@ -1,0 +1,33 @@
+// packages/auth-service/src/middlewares/apiKeyAuth.middleware.ts
+import { NextFunction, Request, Response } from "express";
+import crypto from "crypto";
+import { prisma } from "../db/prismaClient";
+
+function hashKey(raw: string) {
+  return crypto.createHash("sha256").update(raw).digest("hex");
+}
+
+// This middleware checks Authorization: ApiKey <raw> header.
+// If valid, sets req.user = { id: userId, role: 'admin', status: 'verified', apiKeyAuth: true }
+export async function requireApiKey(req: Request, res: Response, next: NextFunction) {
+  try {
+    const auth = req.header("authorization") || "";
+    if (!auth.startsWith("ApiKey ")) return res.status(401).json({ error: { code: "UNAUTHENTICATED", message: "Missing ApiKey" } });
+    const raw = auth.slice("ApiKey ".length).trim();
+    const key_hash = hashKey(raw);
+
+    const rec = await prisma.adminApiKey.findFirst({ where: { key_hash, revoked: false } });
+    if (!rec) return res.status(401).json({ error: { code: "INVALID_API_KEY" } });
+    if (rec.expires_at && rec.expires_at < new Date()) return res.status(401).json({ error: { code: "API_KEY_EXPIRED" } });
+
+    const user = await prisma.user.findUnique({ where: { id: rec.user_id } });
+    if (!user) return res.status(401).json({ error: { code: "INVALID_API_KEY" } });
+
+    // attach user (admin)
+    (req as any).user = { id: user.id, role: user.role, status: user.status, apiKeyAuth: true };
+    next();
+  } catch (e) {
+    console.error("requireApiKey:", e);
+    return res.status(500).json({ error: { code: "INTERNAL_ERROR" } });
+  }
+}

--- a/packages/auth-service/src/routes/admin.routes.ts
+++ b/packages/auth-service/src/routes/admin.routes.ts
@@ -1,11 +1,31 @@
 // packages/auth-service/src/routes/admin.routes.ts
 import { Router } from "express";
 import * as ctrl from "../controllers/admin.controller";
+import { createAdminInvite, registerWithInvite } from "../controllers/adminInvite.controller";
+import { requireAuth, requireRole } from "../middlewares/authz";
+import { requireApiKey } from "../middlewares/apiKeyAuth.middleware";
+import { createAdminApiKey, listAdminApiKeys, revokeAdminApiKey } from "../controllers/adminApiKey.controller";
 
 const router = Router();
 
-// Public admin registration & login (no requireAuth)
-router.post("/admin/register", ctrl.registerAdmin);
+
+// Disable public register — invite flow is used instead
+router.post("/admin/register", (_req, res) => {
+  return res.status(403).json({ error: { code: "DISABLED", message: "Public admin registration disabled. Use invite flow." } });
+});
+
+//public admin login
 router.post("/admin/login", ctrl.loginAdmin);
+
+// Admin-only invite creation
+router.post("/admin/invite", requireAuth, requireRole("admin"), createAdminInvite);
+
+// Public endpoint to register using an invite token (single-use)
+router.post("/admin/register-with-invite", registerWithInvite);
+
+router.post("/admin/apikeys", requireAuth, requireRole("admin"), createAdminApiKey);
+router.get("/admin/apikeys", requireAuth, requireRole("admin"), listAdminApiKeys);
+router.post("/admin/apikeys/:id/revoke", requireAuth, requireRole("admin"), revokeAdminApiKey);
+
 
 export default router;

--- a/packages/auth-service/src/services/adminInvite.service.ts
+++ b/packages/auth-service/src/services/adminInvite.service.ts
@@ -1,0 +1,21 @@
+
+import crypto from "crypto";
+import { prisma } from "../db/prismaClient";
+
+export function genInviteToken(len = 32) {
+  return crypto.randomBytes(len).toString("hex"); // 64 hex chars
+}
+
+export function hashInviteToken(token: string) {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+export async function createAdminInviteRecord(email: string, createdBy: string, daysValid = 7, note?: string) {
+  const token = genInviteToken();
+  const token_hash = hashInviteToken(token);
+  const expires_at = new Date(Date.now() + daysValid * 24 * 60 * 60 * 1000);
+  const invite = await prisma.adminInvite.create({
+    data: { token_hash, email, created_by: createdBy, expires_at, note }
+  });
+  return { invite, raw_token: token };
+}


### PR DESCRIPTION
- Disabled public /admin/register route to prevent arbitrary admin creation
- Implemented admin invite creation (admin-only, token shown once)
- Added /admin/register-with-invite endpoint for new admin onboarding
- Preserved /admin/login for existing admins
- Updated routes to enforce role-based access for invite creation
- Ensured new admins are created with role=admin and status=verified