### PR TITLE
feat(acc-svc,bff): implement beneficiaries & account limit APIs

### DIFF
--- a/packages/account-service/src/app.ts
+++ b/packages/account-service/src/app.ts
@@ -11,6 +11,8 @@ import downloadRouter from "./routes/statements.download";
 import notificationsRouter from "./routes/notification.routes";
 import transferRouter from "./routes/transfers.routes";
 import scheduledRouter from "./routes/scheduledTransfers.routes";
+import beneficiariesRoutes from "./routes/beneficiaries.routes";
+import limitsRoutes from "./routes/limits.routes";
 
 dotenv.config({ override: true });
 const app = express();
@@ -23,13 +25,19 @@ app.use(express.json());
 app.use("/api/v1/accounts", accountsRouter);
 app.use(transferRouter);
 app.use(scheduledRouter);
+
 // app.use('/transactions', ...)
 app.use("/api/v1/transactions", transactionsRouter);
 app.use("/api/v1/statements", statementsRouter);
 app.use(downloadRouter);
+
 // app.use('/limits', ...)
+app.use("/api/v1/limits", limitsRoutes); 
+app.use("/api/v1/beneficiaries", beneficiariesRoutes); 
+
 // app.use('/notifications', ...)
 app.use("/api/v1/notifications", notificationsRouter);
+
 // app.use('/healthz', ...)
 // Health
 app.get("/healthz", (_req, res) => res.status(200).send("ok"));

--- a/packages/account-service/src/controllers/beneficiaries.controller.ts
+++ b/packages/account-service/src/controllers/beneficiaries.controller.ts
@@ -1,0 +1,97 @@
+// packages/account-service/src/controllers/beneficiaries.controller.ts
+import { Request, Response } from "express";
+import { prisma } from "../db/prismaClient";
+
+export const listBeneficiaries = async (req: Request, res: Response) => {
+  try {
+    const userId = (req as any).user?.id;
+    const beneficiaries = await prisma.beneficiary.findMany({
+      where: { user_id: userId, is_active: true },
+      orderBy: { created_at: "desc" },
+    });
+
+    return res.json({ beneficiaries });
+  } catch (err) {
+    console.error("listBeneficiaries error:", err);
+    return res.status(500).json({ error: "Failed to list beneficiaries" });
+  }
+};
+
+export const createBeneficiary = async (req: Request, res: Response) => {
+  try {
+    const userId = (req as any).user?.id;
+    const { name, bank_name, account_number, ifsc_swift, currency } = req.body || {};
+
+    if (!name || !account_number) {
+      return res.status(400).json({ error: "Missing required fields: name, account_number" });
+    }
+
+    const b = await prisma.beneficiary.create({
+      data: {
+        user_id: userId,
+        name,
+        bank_name: bank_name || null,
+        account_number,
+        ifsc_swift: ifsc_swift || null,
+        currency: currency || "INR",
+      },
+    });
+
+    return res.status(201).json({ beneficiary: b });
+  } catch (err) {
+    console.error("createBeneficiary error:", err);
+    return res.status(500).json({ error: "Failed to create beneficiary" });
+  }
+};
+
+export const updateBeneficiary = async (req: Request, res: Response) => {
+  try {
+    const userId = (req as any).user?.id;
+    const { beneficiaryId } = req.params;
+    const { name, bank_name, account_number, ifsc_swift, currency, is_active } = req.body || {};
+
+    const existing = await prisma.beneficiary.findUnique({ where: { id: beneficiaryId } });
+    if (!existing) return res.status(404).json({ error: "Beneficiary not found" });
+    if (existing.user_id !== userId) return res.status(403).json({ error: "Forbidden" });
+
+    const updated = await prisma.beneficiary.update({
+      where: { id: beneficiaryId },
+      data: {
+        name: name ?? existing.name,
+        bank_name: bank_name ?? existing.bank_name,
+        account_number: account_number ?? existing.account_number,
+        ifsc_swift: ifsc_swift ?? existing.ifsc_swift,
+        currency: currency ?? existing.currency,
+        is_active: typeof is_active === "boolean" ? is_active : existing.is_active,
+        updated_at: new Date(),
+      },
+    });
+
+    return res.json({ beneficiary: updated });
+  } catch (err) {
+    console.error("updateBeneficiary error:", err);
+    return res.status(500).json({ error: "Failed to update beneficiary" });
+  }
+};
+
+export const deleteBeneficiary = async (req: Request, res: Response) => {
+  try {
+    const userId = (req as any).user?.id;
+    const { beneficiaryId } = req.params;
+
+    const existing = await prisma.beneficiary.findUnique({ where: { id: beneficiaryId } });
+    if (!existing) return res.status(404).json({ error: "Beneficiary not found" });
+    if (existing.user_id !== userId) return res.status(403).json({ error: "Forbidden" });
+
+    // Soft delete — set is_active = false
+    await prisma.beneficiary.update({
+      where: { id: beneficiaryId },
+      data: { is_active: false, updated_at: new Date() },
+    });
+
+    return res.status(204).send("");
+  } catch (err) {
+    console.error("deleteBeneficiary error:", err);
+    return res.status(500).json({ error: "Failed to delete beneficiary" });
+  }
+};

--- a/packages/account-service/src/controllers/limits.controller.ts
+++ b/packages/account-service/src/controllers/limits.controller.ts
@@ -1,0 +1,75 @@
+// packages/account-service/src/controllers/limits.controller.ts
+import { Request, Response } from "express";
+import { prisma } from "../db/prismaClient";
+
+export const getLimits = async (req: Request, res: Response) => {
+  try {
+    const userId = (req as any).user?.id;
+    const { accountId } = req.query as any;
+
+    if (!accountId) return res.status(400).json({ error: "Missing accountId query param" });
+
+    // verify ownership
+    const acct = await prisma.account.findUnique({ where: { id: accountId } });
+    if (!acct) return res.status(404).json({ error: "Account not found" });
+    if (acct.user_id !== userId) return res.status(403).json({ error: "Forbidden" });
+
+    return res.json({
+      account_id: acct.id,
+      daily_limit: acct.daily_limit ? acct.daily_limit.toString() : null,
+      monthly_limit: acct.monthly_limit ? acct.monthly_limit.toString() : null,
+    });
+  } catch (err) {
+    console.error("getLimits error:", err);
+    return res.status(500).json({ error: "Failed to retrieve limits" });
+  }
+};
+
+export const createLimitRequest = async (req: Request, res: Response) => {
+  try {
+    const userId = (req as any).user?.id;
+    const { account_id, requested_daily_limit, requested_monthly_limit, reason } = req.body || {};
+    if (!account_id || (requested_daily_limit == null && requested_monthly_limit == null)) {
+      return res.status(400).json({ error: "Missing required fields: account_id and requested limits" });
+    }
+
+    // verify ownership
+    const acct = await prisma.account.findUnique({ where: { id: account_id } });
+    if (!acct) return res.status(404).json({ error: "Account not found" });
+    if (acct.user_id !== userId) return res.status(403).json({ error: "Forbidden" });
+
+    const lr = await prisma.limitRequest.create({
+      data: {
+        user_id: userId,
+        account_id,
+        current_daily_limit: acct.daily_limit ?? undefined,
+        current_monthly_limit: acct.monthly_limit ?? undefined,
+        requested_daily_limit: requested_daily_limit ?? undefined,
+        requested_monthly_limit: requested_monthly_limit ?? undefined,
+        reason: reason ?? null,
+        status: "pending",
+      },
+    });
+
+    return res.status(201).json({ limit_request: lr });
+  } catch (err) {
+    console.error("createLimitRequest error:", err);
+    return res.status(500).json({ error: "Failed to submit limit request" });
+  }
+};
+
+export const listMyLimitRequests = async (req: Request, res: Response) => {
+  try {
+    const userId = (req as any).user?.id;
+
+    const requests = await prisma.limitRequest.findMany({
+      where: { user_id: userId },
+      orderBy: { created_at: "desc" },
+    });
+
+    return res.json({ limit_requests: requests });
+  } catch (err) {
+    console.error("listMyLimitRequests error:", err);
+    return res.status(500).json({ error: "Failed to list limit requests" });
+  }
+};

--- a/packages/account-service/src/routes/beneficiaries.routes.ts
+++ b/packages/account-service/src/routes/beneficiaries.routes.ts
@@ -1,0 +1,15 @@
+// packages/account-service/src/routes/beneficiaries.routes.ts
+import { Router } from "express";
+import { requireAuth } from "../middlewares/auth.middleware";
+import { listBeneficiaries, createBeneficiary, updateBeneficiary, deleteBeneficiary } from "../controllers/beneficiaries.controller";
+
+const router = Router();
+
+router.use(requireAuth);
+
+router.get("/", listBeneficiaries);
+router.post("/", createBeneficiary);
+router.put("/:beneficiaryId", updateBeneficiary);
+router.delete("/:beneficiaryId", deleteBeneficiary);
+
+export default router;

--- a/packages/account-service/src/routes/limits.routes.ts
+++ b/packages/account-service/src/routes/limits.routes.ts
@@ -1,0 +1,13 @@
+// packages/account-service/src/routes/limits.routes.ts
+import { Router } from "express";
+import { requireAuth } from "../middlewares/auth.middleware";
+import { getLimits, createLimitRequest, listMyLimitRequests } from "../controllers/limits.controller";
+
+const router = Router();
+router.use(requireAuth);
+
+router.get("/", getLimits); // /api/v1/limits?accountId=...
+router.post("/limit-requests", requireAuth, createLimitRequest);
+router.get("/limit-requests", requireAuth, listMyLimitRequests);
+
+export default router;

--- a/packages/bff/src/app.ts
+++ b/packages/bff/src/app.ts
@@ -16,6 +16,8 @@ import kycBffRouter from "./routes/kyc.bff.routes.js";
 import transactionsBffRouter from "./routes/transactions.bff.routes.js";
 import statementsBffRouter from "./routes/statements.bff.routes.js";
 import notificationsRouter from "./routes/notification.acc.bff.routes.js";
+import beneficiariesBff from "./routes/beneficiaries.bff.routes.js";
+import limitsBff from "./routes/limits.bff.routes.js";
 
 dotenv.config();
 // ✅ emulate __dirname for ESM
@@ -70,6 +72,9 @@ app.use(statementsBffRouter);
 // app.use('/api/v1/transfers', ...)
 
 // app.use('/api/v1/limits', ...)
+app.use(beneficiariesBff);
+app.use(limitsBff);
+
 // app.use('/api/v1/notifications', ...)
 app.use(notificationsRouter);
 

--- a/packages/bff/src/routes/beneficiaries.bff.routes.ts
+++ b/packages/bff/src/routes/beneficiaries.bff.routes.ts
@@ -1,0 +1,51 @@
+// packages/bff/src/routes/beneficiaries.bff.routes.ts
+import { Router } from "express";
+import { accountClient } from "../clients/account.client.js";
+import { forwardContextHeaders } from "../middlewares/auth.forwardContext.js";
+
+const router = Router();
+
+// Note: we expose same paths to frontend and proxy to account-svc
+router.get("/api/v1/beneficiaries", async (req, res, next) => {
+  try {
+    const r = await accountClient.get("/beneficiaries", { headers: forwardContextHeaders(req) });
+    return res.status(r.status).json(r.data);
+  } catch (e: any) {
+    if (e.response) return res.status(e.response.status).json(e.response.data);
+    next(e);
+  }
+});
+
+router.post("/api/v1/beneficiaries", async (req, res, next) => {
+  try {
+    const r = await accountClient.post("/beneficiaries", req.body, { headers: forwardContextHeaders(req) });
+    return res.status(r.status).json(r.data);
+  } catch (e: any) {
+    if (e.response) return res.status(e.response.status).json(e.response.data);
+    next(e);
+  }
+});
+
+router.put("/api/v1/beneficiaries/:beneficiaryId", async (req, res, next) => {
+  try {
+    const { beneficiaryId } = req.params;
+    const r = await accountClient.put(`/beneficiaries/${encodeURIComponent(beneficiaryId)}`, req.body, { headers: forwardContextHeaders(req) });
+    return res.status(r.status).json(r.data);
+  } catch (e: any) {
+    if (e.response) return res.status(e.response.status).json(e.response.data);
+    next(e);
+  }
+});
+
+router.delete("/api/v1/beneficiaries/:beneficiaryId", async (req, res, next) => {
+  try {
+    const { beneficiaryId } = req.params;
+    const r = await accountClient.delete(`/beneficiaries/${encodeURIComponent(beneficiaryId)}`, { headers: forwardContextHeaders(req) });
+    return res.status(r.status).json(r.data);
+  } catch (e: any) {
+    if (e.response) return res.status(e.response.status).json(e.response.data);
+    next(e);
+  }
+});
+
+export default router;

--- a/packages/bff/src/routes/limits.bff.routes.ts
+++ b/packages/bff/src/routes/limits.bff.routes.ts
@@ -1,0 +1,40 @@
+// packages/bff/src/routes/limits.bff.routes.ts
+import { Router } from "express";
+import { accountClient } from "../clients/account.client.js";
+import { forwardContextHeaders } from "../middlewares/auth.forwardContext.js";
+
+const router = Router();
+
+router.get("/api/v1/limits", async (req, res, next) => {
+  try {
+    const r = await accountClient.get("/limits", { params: req.query, headers: forwardContextHeaders(req) });
+    return res.status(r.status).json(r.data);
+  } catch (e: any) {
+    if (e.response) return res.status(e.response.status).json(e.response.data);
+    next(e);
+  }
+});
+
+// create limit request
+router.post("/api/v1/limit-requests", async (req, res, next) => {
+  try {
+    const r = await accountClient.post("/limits/limit-requests", req.body, { headers: forwardContextHeaders(req) });
+    return res.status(r.status).json(r.data);
+  } catch (e: any) {
+    if (e.response) return res.status(e.response.status).json(e.response.data);
+    next(e);
+  }
+});
+
+// list my limit requests
+router.get("/api/v1/limit-requests", async (req, res, next) => {
+  try {
+    const r = await accountClient.get("/limits/limit-requests", { headers: forwardContextHeaders(req) });
+    return res.status(r.status).json(r.data);
+  } catch (e: any) {
+    if (e.response) return res.status(e.response.status).json(e.response.data);
+    next(e);
+  }
+});
+
+export default router;


### PR DESCRIPTION
Beneficiaries APIs

Added GET /api/v1/beneficiaries → list user’s beneficiaries.

Added POST /api/v1/beneficiaries → add a new beneficiary (with bank name, account number, IFSC/SWIFT, currency, etc.).

Added PUT /api/v1/beneficiaries/:id → update beneficiary details (e.g. name, is_active).

Added DELETE /api/v1/beneficiaries/:id → remove a beneficiary.

Account Limits APIs

Added GET /api/v1/limits?accountId=... → fetch current daily & monthly transaction limits for an account.

Added POST /api/v1/limit-requests → submit a new limit increase request (daily/monthly).

Added GET /api/v1/limit-requests → list all limit requests submitted by the current user.

Implementation details

Enforced ownership checks to ensure a user can only access/update their own beneficiaries and accounts.

Used Prisma transactions where necessary.

Added corresponding BFF routes for proxying requests from frontend to account-service.

Tested all endpoints with Postman — verified working end-to-end.