### PR TITLE
feat(acc-svc,bff): implement loan APIs (list, detail, schedule) with …

### DIFF
--- a/packages/account-service/scripts/attachBranchToAccount.ts
+++ b/packages/account-service/scripts/attachBranchToAccount.ts
@@ -1,0 +1,49 @@
+// packages/account-service/scripts/attachBranchToAccount.ts
+import dotenv from "dotenv";
+import { PrismaClient } from "@prisma/client";
+
+dotenv.config();
+const prisma = new PrismaClient();
+
+async function main() {
+  const accountId = process.env.TEST_ACCOUNT_ID; // set in .env before running
+  const branchId = process.env.TEST_BRANCH_ID;   // set in .env before running
+
+  if (!accountId || !branchId) {
+    throw new Error("Please set TARGET_ACCOUNT_ID and TARGET_BRANCH_ID in .env");
+  }
+
+  // Optional: verify branch and account exist and that account belongs to expected user
+  const [acct, br] = await Promise.all([
+    prisma.account.findUnique({ where: { id: accountId } }),
+    prisma.branch.findUnique({ where: { id: branchId } }),
+  ]);
+
+  if (!acct) throw new Error(`Account not found: ${accountId}`);
+  if (!br) throw new Error(`Branch not found: ${branchId}`);
+
+  // Atomic update (simple update inside transaction)
+  await prisma.$transaction(async (tx) => {
+    await tx.account.update({
+      where: { id: accountId },
+      data: { branch_id: branchId },
+    });
+
+    // optional audit log
+    await tx.auditLog.create({
+      data: {
+        user_id: acct.user_id,
+        action: "assign_branch",
+        details: `Assigned branch ${br.code} (${branchId}) to account ${acct.account_number}`,
+      },
+    });
+  });
+
+  console.log(`Success: account ${accountId} now assigned to branch ${branchId}`);
+  await prisma.$disconnect();
+}
+
+main().catch((err) => {
+  console.error("ERROR:", err);
+  process.exit(1);
+});

--- a/packages/account-service/scripts/createBranch.ts
+++ b/packages/account-service/scripts/createBranch.ts
@@ -1,0 +1,25 @@
+import { PrismaClient } from "@prisma/client";
+import { randomUUID } from "crypto";
+import dotenv from "dotenv";
+dotenv.config();
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const id = randomUUID();
+  const name = process.env.TEST_BRANCH_NAME || "Local Branch";
+  const code = process.env.TEST_BRANCH_CODE || `BR-${Date.now()}`;
+
+  const br = await prisma.branch.create({
+    data: {
+      id,
+      name,
+      code,
+      address: process.env.TEST_BRANCH_ADDRESS || null,
+    }
+  });
+  console.log("Created branch:", br);
+  await prisma.$disconnect();
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/packages/account-service/scripts/createLoan.ts
+++ b/packages/account-service/scripts/createLoan.ts
@@ -1,0 +1,70 @@
+// packages/account-service/scripts/createLoan.ts
+import { PrismaClient } from "@prisma/client";
+import { randomUUID } from "crypto";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+const prisma = new PrismaClient();
+
+function isNonEmptyString(v?: string) {
+  return typeof v === "string" && v.trim().length > 0;
+}
+
+async function main() {
+  // Read environment / edit as needed
+  const loanId = process.env.TEST_LOAN_ID || randomUUID();
+  const userId = process.env.TEST_USER_ID;
+  const accountId = process.env.TEST_ACCOUNT_ID;
+  const branchId = process.env.TEST_BRANCH_ID || null; // optional
+  const principal = process.env.LOAN_PRINCIPAL || "50000.00";
+  const interest = process.env.LOAN_INTEREST || "8.5";
+  const startDate = new Date(process.env.LOAN_START || new Date().toISOString());
+  const endDate = new Date(process.env.LOAN_END || new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString()); // 1y default
+
+  if (!userId) throw new Error("Set TEST_USER_ID in env");
+  if (!accountId) throw new Error("Set TEST_ACCOUNT_ID in env (existing account id)");
+
+  console.log("Creating loan with:", {
+    loanId, userId, accountId, branchId, principal, interest, startDate: startDate.toISOString(), endDate: endDate.toISOString(),
+  });
+
+  try {
+    // Build data object — connect relations explicitly
+    const data: any = {
+      id: loanId,
+      user_id: userId,
+      // connect the account relation (ensures Prisma knows the relation target)
+      account: { connect: { id: accountId } },
+      amount: principal,         // Prisma Decimal accepts string
+      interest_rate: interest,   // string is okay; Prisma will coerce Decimal
+      start_date: startDate,
+      end_date: endDate,
+      status: "active",
+      created_at: new Date(),
+      branch: null, // Add this line
+    };
+
+    // If branchId provided (non-empty), connect it too
+    if (branchId !== null && isNonEmptyString(branchId)) {
+    data.branch = { connect: { id: branchId } };
+    }
+
+    const loan = await prisma.loan.create({ data });
+    console.log("SUCCESS: created loan:", {
+      id: loan.id,
+      amount: loan.amount?.toString?.(),
+      interest_rate: loan.interest_rate?.toString?.(),
+    });
+  } catch (err) {
+    console.error("ERROR creating loan:", err);
+    throw err;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((e) => {
+  console.error("FATAL:", e);
+  process.exit(1);
+});

--- a/packages/account-service/src/app.ts
+++ b/packages/account-service/src/app.ts
@@ -13,6 +13,7 @@ import transferRouter from "./routes/transfers.routes";
 import scheduledRouter from "./routes/scheduledTransfers.routes";
 import beneficiariesRoutes from "./routes/beneficiaries.routes";
 import limitsRoutes from "./routes/limits.routes";
+import loansRouter from "./routes/loans.routes";
 
 dotenv.config({ override: true });
 const app = express();
@@ -37,6 +38,8 @@ app.use("/api/v1/beneficiaries", beneficiariesRoutes);
 
 // app.use('/notifications', ...)
 app.use("/api/v1/notifications", notificationsRouter);
+
+app.use("/api/v1/loans", loansRouter);
 
 // app.use('/healthz', ...)
 // Health

--- a/packages/account-service/src/controllers/loans.controller.ts
+++ b/packages/account-service/src/controllers/loans.controller.ts
@@ -1,0 +1,130 @@
+// packages/account-service/src/controllers/loans.controller.ts
+import { Request, Response } from "express";
+import { prisma } from "../db/prismaClient";
+
+function fmtLoan(l: any) {
+  return {
+    id: l.id,
+    user_id: l.user_id,
+    account_id: l.account_id,
+    branch_id: l.branch_id,
+    amount: l.amount?.toString?.() ?? l.amount,
+    interest_rate: l.interest_rate?.toString?.() ?? l.interest_rate,
+    start_date: l.start_date?.toISOString?.() ?? l.start_date,
+    end_date: l.end_date?.toISOString?.() ?? l.end_date,
+    status: l.status,
+    created_at: l.created_at?.toISOString?.() ?? l.created_at,
+  };
+}
+function generateAmortizationSchedule(principal: number, annualRatePct: number, startDate: Date, months: number) {
+  const monthlyRate = (annualRatePct / 100) / 12;
+  const n = months;
+  // monthly payment using annuity formula
+  const monthlyPayment = monthlyRate === 0 ? principal / n : (principal * monthlyRate) / (1 - Math.pow(1 + monthlyRate, -n));
+  let balance = principal;
+  const schedule: any[] = [];
+
+  for (let i = 1; i <= n; i++) {
+    const interest = monthlyRate * balance;
+    const principalPortion = monthlyPayment - interest;
+    balance = Math.max(0, balance - principalPortion);
+
+    const due = new Date(startDate);
+    due.setMonth(due.getMonth() + i - 1);
+
+    schedule.push({
+      installment_number: i,
+      due_date: due.toISOString(),
+      principal: principalPortion.toFixed(2),
+      interest: interest.toFixed(2),
+      total_payment: monthlyPayment.toFixed(2),
+      remaining_balance: balance.toFixed(2),
+    });
+  }
+
+  return {
+    monthly_payment: monthlyPayment.toFixed(2),
+    term_months: n,
+    schedule,
+  };
+}
+
+/** GET /api/v1/loans - list loans for authenticated user */
+export const listLoans = async (req: Request, res: Response) => {
+  try {
+    const userId = (req as any).user?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+    const loans = await prisma.loan.findMany({
+      where: { user_id: userId },
+      orderBy: { created_at: "desc" },
+      select: {
+        id: true,
+        amount: true,
+        interest_rate: true,
+        start_date: true,
+        end_date: true,
+        status: true,
+        branch_id: true,
+      },
+    });
+
+    const formatted = loans.map(fmtLoan);
+
+    return res.json({ loans: loans.map(fmtLoan) });
+  } catch (err) {
+    console.error("listLoans error:", err);
+    return res.status(500).json({ error: "Failed to retrieve loans" });
+  }
+};
+
+/** GET /api/v1/loans/:loanId - loan detail */
+export const getLoan = async (req: Request, res: Response) => {
+  try {
+    const userId = (req as any).user?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+    const { loanId } = req.params;
+    const loan = await prisma.loan.findUnique({
+      where: { id: loanId },
+      include: { account: true, branch: true },
+    });
+
+    if (!loan) return res.status(404).json({ error: "Loan not found" });
+    if (loan.user_id !== userId) return res.status(403).json({ error: "Forbidden" });
+
+    return res.json({ loan: fmtLoan(loan) });
+  } catch (err) {
+    console.error("getLoan error:", err);
+    return res.status(500).json({ error: "Failed to retrieve loan" });
+  }
+};
+
+/** GET /api/v1/loans/:loanId/schedule - amortization schedule */
+export const getLoanSchedule = async (req: Request, res: Response) => {
+  try {
+    const userId = (req as any).user?.id;
+    if (!userId) return res.status(401).json({ error: "Unauthorized" });
+
+    const { loanId } = req.params;
+    const loan = await prisma.loan.findUnique({ where: { id: loanId } });
+    if (!loan) return res.status(404).json({ error: "Loan not found" });
+    if (loan.user_id !== userId) return res.status(403).json({ error: "Forbidden" });
+
+    // If loan has start_date and end_date, compute months
+    const start = loan.start_date;
+    const end = loan.end_date || new Date(start.getTime());
+    // compute months difference (round to nearest whole months)
+    const months = Math.max(1, Math.round(((end.getFullYear() - start.getFullYear()) * 12) + (end.getMonth() - start.getMonth())));
+    const principal = parseFloat((loan.amount as any).toString());
+    const schedule = generateAmortizationSchedule(principal, parseFloat((loan.interest_rate as any).toString()), start, months);
+
+    return res.json({
+      loan: fmtLoan(loan),
+      schedule,
+    });
+  } catch (err) {
+    console.error("getLoanSchedule error:", err);
+    return res.status(500).json({ error: "Failed to generate schedule" });
+  }
+};

--- a/packages/account-service/src/routes/loans.routes.ts
+++ b/packages/account-service/src/routes/loans.routes.ts
@@ -1,0 +1,12 @@
+// packages/account-service/src/routes/loans.routes.ts
+import { Router } from "express";
+import { listLoans, getLoan, getLoanSchedule } from "../controllers/loans.controller";
+import { requireAuth } from "../middlewares/auth.middleware"; // keep same middleware path
+
+const router = Router();
+
+router.get("/", requireAuth, listLoans);
+router.get("/:loanId", requireAuth, getLoan);
+router.get("/:loanId/schedule", requireAuth, getLoanSchedule);
+
+export default router;

--- a/packages/bff/src/app.ts
+++ b/packages/bff/src/app.ts
@@ -18,6 +18,7 @@ import statementsBffRouter from "./routes/statements.bff.routes.js";
 import notificationsRouter from "./routes/notification.acc.bff.routes.js";
 import beneficiariesBff from "./routes/beneficiaries.bff.routes.js";
 import limitsBff from "./routes/limits.bff.routes.js";
+import loansBff from "./routes/loans.bff.routes.js";
 
 dotenv.config();
 // ✅ emulate __dirname for ESM
@@ -77,6 +78,8 @@ app.use(limitsBff);
 
 // app.use('/api/v1/notifications', ...)
 app.use(notificationsRouter);
+
+app.use(loansBff);
 
 app.use(errorHandler);
 

--- a/packages/bff/src/routes/loans.bff.routes.ts
+++ b/packages/bff/src/routes/loans.bff.routes.ts
@@ -1,0 +1,41 @@
+// packages/bff/src/routes/loans.bff.routes.ts
+import { Router } from "express";
+import { accountClient } from "../clients/account.client.js";
+import { forwardContextHeaders } from "../middlewares/auth.forwardContext.js";
+
+const router = Router();
+
+
+router.get("/api/v1/loans", async (req, res, next) => {
+  try {
+    const r = await accountClient.get("/loans", { headers: forwardContextHeaders(req) });
+    return res.status(r.status).json(r.data);
+  } catch (e: any) {
+    if (e.response) return res.status(e.response.status).json(e.response.data);
+    next(e);
+  }
+});
+
+
+router.get("/api/v1/loans/:loanId", async (req, res, next) => {
+  try {
+    const r = await accountClient.get(`/loans/${encodeURIComponent(req.params.loanId)}`, { headers: forwardContextHeaders(req) });
+    return res.status(r.status).json(r.data);
+  } catch (e: any) {
+    if (e.response) return res.status(e.response.status).json(e.response.data);
+    next(e);
+  }
+});
+
+
+router.get("/api/v1/loans/:loanId/schedule", async (req, res, next) => {
+  try {
+    const r = await accountClient.get(`/loans/${encodeURIComponent(req.params.loanId)}/schedule`, { headers: forwardContextHeaders(req) });
+    return res.status(r.status).json(r.data);
+  } catch (e: any) {
+    if (e.response) return res.status(e.response.status).json(e.response.data);
+    next(e);
+  }
+});
+
+export default router;


### PR DESCRIPTION
…amortization support

### Added
- **Account Service**
  - `loans.controller.ts`: Implemented
    - `listLoans` – fetch all loans for authenticated user
    - `getLoan` – retrieve loan details with ownership check
    - `getLoanSchedule` – generate amortization schedule using annuity formula
  - Loan formatting helper to normalize Decimal/Date fields
  - Scripts to create test loan and branch entries for local testing

- **BFF Service**
  - Forwarding routes under `/api/v1/loans` for:
    - Loan list
    - Loan detail
    - Loan amortization schedule

### Fixed
- Properly handle missing/invalid loan IDs with 404 and ownership validation with 403.
- Safe conversion of Prisma `Decimal` and `Date` fields to JSON serializable strings.

### Notes
- Loan APIs currently support **read-only access** (list/detail/schedule).
- Loan creation is seeded via script (`createLoan.ts`), not user-facing.
- Amortization schedule ensures monthly installment breakdown (principal, interest, balance).

This commit enables the frontend dashboard to display loan portfolios and repayment schedules to end users.
